### PR TITLE
Add CLUSTER_NAME setting to all updated deployments.

### DIFF
--- a/frankfurt/snippets-prod/deploy.yaml
+++ b/frankfurt/snippets-prod/deploy.yaml
@@ -89,6 +89,8 @@ items:
               secretKeyRef:
                 key: cdn-url
                 name: snippets-prod-v211-env
+          - name: CLUSTER_NAME
+            value: "frankfurt"
           - name: CSP_REPORT_ENABLE
             valueFrom:
               secretKeyRef:

--- a/oregon-b/snippets-admin/deploy.yaml
+++ b/oregon-b/snippets-admin/deploy.yaml
@@ -88,6 +88,8 @@ spec:
             secretKeyRef:
               key: cdn-url
               name: snippets-admin-v140-env
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ENABLE
           valueFrom:
             secretKeyRef:

--- a/oregon-b/snippets-dev/clock-deploy.yaml
+++ b/oregon-b/snippets-dev/clock-deploy.yaml
@@ -64,6 +64,8 @@ spec:
             secretKeyRef:
               key: cache-url
               name: snippets-dev-secrets
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ONLY
           value: "True"
         - name: CSV_EXPORT_ROOT

--- a/oregon-b/snippets-dev/deploy.yaml
+++ b/oregon-b/snippets-dev/deploy.yaml
@@ -67,6 +67,8 @@ spec:
             secretKeyRef:
               key: cache-url
               name: snippets-dev-secrets
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ONLY
           value: "True"
         - name: CSV_EXPORT_ROOT

--- a/oregon-b/snippets-prod/deploy.yaml
+++ b/oregon-b/snippets-prod/deploy.yaml
@@ -76,6 +76,8 @@ spec:
               name: snippets-prod-secrets
         - name: CDN_URL
           value: https://snippets.cdn.mozilla.net
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ENABLE
           value: "False"
         - name: CSP_REPORT_ONLY

--- a/oregon-b/snippets-stage/clock-deploy.yaml
+++ b/oregon-b/snippets-stage/clock-deploy.yaml
@@ -64,6 +64,8 @@ spec:
             secretKeyRef:
               key: cache-url
               name: snippets-stage-secrets
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ENABLE
           value: "False"
         - name: CSP_REPORT_ONLY

--- a/oregon-b/snippets-stage/deploy.yaml
+++ b/oregon-b/snippets-stage/deploy.yaml
@@ -67,6 +67,8 @@ spec:
             secretKeyRef:
               key: cache-url
               name: snippets-stage-secrets
+        - name: CLUSTER_NAME
+          value: "oregon-b"
         - name: CSP_REPORT_ENABLE
           value: "False"
         - name: CSP_REPORT_ONLY


### PR DESCRIPTION
Companion to mozmeao/snippets-service#1052

Added setting in `clock-deploy.yaml` just in case, even though we might be dropping them.